### PR TITLE
security: constant-time pairing code comparison (timing attack fix)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,6 +85,9 @@ toml = "1.1"
 # Binary path resolution (for agent command validation)
 which = "7"
 
+# Constant-time comparison (prevents timing side-channel on pairing codes)
+subtle = "2"
+
 [dev-dependencies]
 mockito = "1.2"
 tempfile = "3.10"

--- a/src/pairing.rs
+++ b/src/pairing.rs
@@ -1,5 +1,6 @@
 use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
 use std::time::{Duration, Instant};
+use subtle::ConstantTimeEq;
 use thiserror::Error;
 
 /// Errors that can occur during pairing
@@ -192,8 +193,11 @@ impl PairingManager {
             return Err(PairingError::InvalidCode);
         }
 
-        // Validate code
-        if code != self.code {
+        // Validate code using constant-time comparison to prevent timing side-channel attacks.
+        // A standard != on a 6-digit string would leak information about how many characters
+        // match, reducing the effective search space before the rate limit is reached.
+        let code_matches = code.as_bytes().ct_eq(self.code.as_bytes());
+        if code_matches.unwrap_u8() == 0 {
             self.attempts.fetch_add(1, Ordering::SeqCst);
             return Err(PairingError::InvalidCode);
         }


### PR DESCRIPTION
## Summary

The 6-digit pairing code in `pairing.rs` was validated with a plain `!=` comparison:

```rust
// Before
if code != self.code {
```

Standard string equality short-circuits on the first mismatched byte, leaking timing information. With only 10⁶ possible codes and 5 attempts per code lifetime, repeated measurements of response latency can narrow the search space before the rate limit is hit.

## Fix

Replace with `subtle::ConstantTimeEq`, which compares all bytes regardless of where the first mismatch occurs:

```rust
// After
let code_matches = code.as_bytes().ct_eq(self.code.as_bytes());
if code_matches.unwrap_u8() == 0 {
```

The [`subtle`](https://crates.io/crates/subtle) crate is from the RustCrypto project and is the standard Rust solution for constant-time comparisons. It is `#[no_std]`-compatible and has no transitive dependencies.

## Testing

All 63 existing tests pass unchanged. The behaviour is identical for valid codes — only the timing characteristics change.